### PR TITLE
Add basic serialization to JSON for Result

### DIFF
--- a/extractor/Pipfile
+++ b/extractor/Pipfile
@@ -19,6 +19,7 @@ pandas = "*"
 lxml = "*"
 cssselect = "*"
 requests = "*"
+defusedxml = "*"
 
 [requires]
 python_version = "3.8"

--- a/extractor/Pipfile.lock
+++ b/extractor/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5e33e793b0f3af923b854fadab89f2dc45ed75cbbdcf3b68fd5c2fb708debe37"
+            "sha256": "60bb1b926ed75f6964301c60398b2e8581e8696c2bf64dae6f472a42ed447fca"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,6 +37,14 @@
             ],
             "index": "pypi",
             "version": "==1.1.0"
+        },
+        "defusedxml": {
+            "hashes": [
+                "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
+                "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
+            ],
+            "index": "pypi",
+            "version": "==0.6.0"
         },
         "idna": {
             "hashes": [

--- a/extractor/extractor/__main__.py
+++ b/extractor/extractor/__main__.py
@@ -1,4 +1,6 @@
 from extractor import app
+import sys
+from ._options import parser, Options
 
 if __name__ == "__main__":
     import logging
@@ -6,4 +8,7 @@ if __name__ == "__main__":
     logging.basicConfig()
     logger = logging.getLogger(__package__)
 
-    app.run()
+    args = parser.parse_args(sys.argv[1:])
+    options = Options.from_args(args)
+
+    app.run(options)

--- a/extractor/extractor/_options.py
+++ b/extractor/extractor/_options.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from argparse import ArgumentParser, Namespace
+from typing import NamedTuple
+
+
+parser = ArgumentParser(
+    prog="extractor",
+    description="A utility to extract and serialize IRS 990 data.",
+    epilog="A project of Code for Montana.",
+)
+
+parser.add_argument(
+    "--version", "-v", action="version", version="0.0.1",
+)
+
+parser.add_argument(
+    "--to-json",
+    action="store_true",
+    default=False,
+    help="Output extracted data to JSON",
+)
+
+
+class Options(NamedTuple):
+    @staticmethod
+    def from_args(args: Namespace) -> Options:
+        return Options(to_json=args.to_json,)
+
+    to_json: bool

--- a/extractor/extractor/app.py
+++ b/extractor/extractor/app.py
@@ -1,7 +1,10 @@
-import io
-from . import HTTPDownloader, Index, DirectoryCache, MemoryCache, Result
+import json
+from .cache import DirectoryCache, MemoryCache
+from .downloader import HTTPDownloader
 from .filing import Filing
-from .index import IndexRecord
+from .index import Index, IndexRecord
+from .result import Result
+from ._options import Options
 
 
 def _filter_taxpayer_name(record: IndexRecord) -> bool:
@@ -14,13 +17,18 @@ def _filter_website(filing: Filing) -> bool:
     return filing.website_address is not None
 
 
-def run():
+def run(options: Options):
     result = Result(
         HTTPDownloader(
             "https://s3.amazonaws.com/irs-form-990", DirectoryCache()
         ),
-        Index(io.open("fixtures/index.csv")).filter(_filter_taxpayer_name),
+        Index(open("fixtures/index.csv", "r")).filter(_filter_taxpayer_name),
     )
+
+    if options.to_json:
+        print(json.dumps(result.to_json()))
+        return
+
     for filing in result.filter(_filter_website):
         print("-----------------------------")
         print(filing.principal_officer_name)

--- a/extractor/extractor/cache.py
+++ b/extractor/extractor/cache.py
@@ -10,7 +10,7 @@ class Cache:
     TODO: Should both methods return strings, or both TextIOs?
     """
 
-    def get(self, object_id: str) -> str:
+    def get(self, object_id: str) -> Optional[str]:
         raise NotImplementedError()
 
     def put(self, object_id: str, content: str) -> str:
@@ -27,7 +27,7 @@ class MemoryCache(Cache):
     def __init__(self):
         self._dict = {}
 
-    def get(self, object_id: str) -> str:
+    def get(self, object_id: str) -> Optional[str]:
         return self._dict.get(object_id, None)
 
     def put(self, object_id: str, content: str) -> str:
@@ -66,11 +66,12 @@ class DirectoryCache(Cache):
         os.mkdir(path)
         self._path = path
 
-    def get(self, object_id: str) -> str:
+    def get(self, object_id: str) -> Optional[str]:
         path = os.path.join(self._path, f"{object_id}_public.xml")
         if os.path.exists(path) and os.path.isfile(path):
             with open(path) as xml:
                 return xml.read()
+        return None
 
     def put(self, object_id: str, content: str) -> str:
         path = os.path.join(self._path, f"{object_id}_public.xml")

--- a/extractor/extractor/result.py
+++ b/extractor/extractor/result.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable, Iterable, Iterator, Optional, NamedTuple
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, NamedTuple
 
 from .downloader import Downloader
 from .filing import Filing
@@ -72,3 +72,13 @@ class Result:
 
     def take(self, n: int) -> Result:
         pass
+
+    def to_json(self) -> Dict[str, Any]:
+        """
+        Convert the result into JSON suitable for use as data for modules.
+
+        TODO: Think about additional metadata we might want
+        """
+        return {
+            "filings": [f.to_json() for f in self],
+        }

--- a/extractor/mypy.ini
+++ b/extractor/mypy.ini
@@ -1,0 +1,3 @@
+[mypy-defusedxml]
+ignore_missing_imports = True
+


### PR DESCRIPTION
Closes #42 

We want to be able to serialize a set of `Filing`s to JSON so that they can be used by the client modules. Add a basic capability to do that.

**Merging into my other branch right now to keep the diff clean. #41 should merge first and then this can be re-targeted to master.**